### PR TITLE
Fix missing transactional

### DIFF
--- a/src/test/java/com/acme/conferencesystem/cfp/proposals/persistence/ProposalRepositoryTest.java
+++ b/src/test/java/com/acme/conferencesystem/cfp/proposals/persistence/ProposalRepositoryTest.java
@@ -4,6 +4,7 @@ import com.acme.conferencesystem.AbstractIntegrationTest;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.instancio.Select.field;
@@ -14,6 +15,7 @@ public class ProposalRepositoryTest extends AbstractIntegrationTest {
     ProposalRepository repository;
 
     @Test
+    @Transactional
     void save() {
         var entity = Instancio.of(ProposalEntity.class).ignore(field(ProposalEntity::id)).create();
 

--- a/src/test/java/com/acme/conferencesystem/users/persistence/UsersRepositoryTest.java
+++ b/src/test/java/com/acme/conferencesystem/users/persistence/UsersRepositoryTest.java
@@ -4,6 +4,7 @@ import com.acme.conferencesystem.AbstractIntegrationTest;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.instancio.Select.field;
@@ -14,6 +15,7 @@ class UsersRepositoryTest extends AbstractIntegrationTest {
     UsersRepository repository;
 
     @Test
+    @Transactional
     void save() {
         var entity = Instancio.of(UserEntity.class).ignore(field(UserEntity::id)).create();
 


### PR DESCRIPTION
Repositories tests were not in a transaction, so the test data was not cleaned after test execution, and the end-to-end tests were failing because there was more data than expected in the database.