### PR TITLE
15-vertical-slicing-testing

### DIFF
--- a/src/test/java/com/acme/conferencesystem/AbstractIntegrationTest.java
+++ b/src/test/java/com/acme/conferencesystem/AbstractIntegrationTest.java
@@ -4,12 +4,10 @@ import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.BeforeEach;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {}, classes = ContainerConfig.class)
 public class AbstractIntegrationTest {
 
     protected RequestSpecification requestSpecification;

--- a/src/test/java/com/acme/conferencesystem/ApplicationTests.java
+++ b/src/test/java/com/acme/conferencesystem/ApplicationTests.java
@@ -1,13 +1,16 @@
 package com.acme.conferencesystem;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.modulith.test.ApplicationModuleTest;
 
+@ApplicationModuleTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(ContainerConfig.class)
 class ApplicationTests extends AbstractIntegrationTest {
-
 
     @Test
     void test() {
     }
-
 
 }

--- a/src/test/java/com/acme/conferencesystem/ArchitectureTests.java
+++ b/src/test/java/com/acme/conferencesystem/ArchitectureTests.java
@@ -9,6 +9,11 @@ class ArchitectureTests {
     ApplicationModules modules = ApplicationModules.of(Application.class);
 
     @Test
+    void printModuleArrangement() {
+        modules.forEach(System.out::println);
+    }
+
+    @Test
     void verifyModularStructure() {
         modules.verify();
     }

--- a/src/test/java/com/acme/conferencesystem/cfp/proposals/http/ProposalControllerIntegrationTest.java
+++ b/src/test/java/com/acme/conferencesystem/cfp/proposals/http/ProposalControllerIntegrationTest.java
@@ -1,14 +1,20 @@
 package com.acme.conferencesystem.cfp.proposals.http;
 
 import com.acme.conferencesystem.AbstractIntegrationTest;
+import com.acme.conferencesystem.ContainerConfig;
 import com.acme.conferencesystem.cfp.proposals.business.Proposal;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.modulith.test.ApplicationModuleTest;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
+@ApplicationModuleTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(ContainerConfig.class)
 class ProposalControllerIntegrationTest extends AbstractIntegrationTest {
 
     @Test

--- a/src/test/java/com/acme/conferencesystem/cfp/proposals/persistence/ProposalRepositoryTest.java
+++ b/src/test/java/com/acme/conferencesystem/cfp/proposals/persistence/ProposalRepositoryTest.java
@@ -1,15 +1,19 @@
 package com.acme.conferencesystem.cfp.proposals.persistence;
 
-import com.acme.conferencesystem.AbstractIntegrationTest;
+import com.acme.conferencesystem.ContainerConfig;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.modulith.test.ApplicationModuleTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.instancio.Select.field;
 
-public class ProposalRepositoryTest extends AbstractIntegrationTest {
+@ApplicationModuleTest
+@Import(ContainerConfig.class)
+public class ProposalRepositoryTest {
 
     @Autowired
     ProposalRepository repository;

--- a/src/test/java/com/acme/conferencesystem/users/http/UserControllerTest.java
+++ b/src/test/java/com/acme/conferencesystem/users/http/UserControllerTest.java
@@ -1,15 +1,21 @@
 package com.acme.conferencesystem.users.http;
 
 import com.acme.conferencesystem.AbstractIntegrationTest;
+import com.acme.conferencesystem.ContainerConfig;
 import com.acme.conferencesystem.users.business.User;
 import com.acme.conferencesystem.users.business.UserRole;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.modulith.test.ApplicationModuleTest;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
+@ApplicationModuleTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(ContainerConfig.class)
 class UserControllerTest extends AbstractIntegrationTest {
 
     public static final String JOHN_DOE = "John Doe";

--- a/src/test/java/com/acme/conferencesystem/users/persistence/UsersRepositoryTest.java
+++ b/src/test/java/com/acme/conferencesystem/users/persistence/UsersRepositoryTest.java
@@ -1,15 +1,19 @@
 package com.acme.conferencesystem.users.persistence;
 
-import com.acme.conferencesystem.AbstractIntegrationTest;
+import com.acme.conferencesystem.ContainerConfig;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.modulith.test.ApplicationModuleTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.instancio.Select.field;
 
-class UsersRepositoryTest extends AbstractIntegrationTest {
+@ApplicationModuleTest
+@Import(ContainerConfig.class)
+class UsersRepositoryTest {
 
     @Autowired
     UsersRepository repository;


### PR DESCRIPTION
- Added vertical slice testing by module. 
Instead of 
```java
@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {}, classes = ContainerConfig.class)
```
do 
```java
@ApplicationModuleTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@Import(ContainerConfig.class)
```
- Added test to print module information. 

```java
@Test
    void printModuleArrangement() {
        modules.forEach(System.out::println);
    }
```

That print

```bash
# Cfp
> Logical name: cfp
> Base package: com.acme.conferencesystem.cfp
> Spring beans:
  o ….proposals.business.ProposalMapperImpl
  o ….proposals.business.ProposalService
  o ….proposals.http.ProposalController
  o ….proposals.persistence.ProposalRepository

# Users
> Logical name: users
> Base package: com.acme.conferencesystem.users
> Spring beans:
  o ….business.UserMapperImpl
  o ….business.UserService
  o ….http.UserController
  o ….persistence.UsersRepository
```