### PR TITLE
fix/fix-hikari-connecitons-not-released

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
 
 logging:
   level:
-    org.springframework: debug
+    org.springframework: info
 
 server:
   error:

--- a/src/test/java/com/acme/conferencesystem/ContainerConfig.java
+++ b/src/test/java/com/acme/conferencesystem/ContainerConfig.java
@@ -3,7 +3,6 @@ package com.acme.conferencesystem;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import javax.sql.DataSource;
-import org.springframework.boot.devtools.restart.RestartScope;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
@@ -12,26 +11,32 @@ import org.testcontainers.containers.PostgreSQLContainer;
 @TestConfiguration(proxyBeanMethods = false)
 public class ContainerConfig {
 
-    //Avoids datasource recreation
-    @Bean
-    @RestartScope
-    public DataSource dataSource(PostgreSQLContainer<?> postgreSQLContainer) {
-        HikariConfig hikariConfig = new HikariConfig();
-        hikariConfig.setDriverClassName("org.postgresql.Driver");
-        hikariConfig.setJdbcUrl(postgreSQLContainer.getJdbcUrl());
-        hikariConfig.setUsername(postgreSQLContainer.getUsername());
-        hikariConfig.setPassword(postgreSQLContainer.getPassword());
-        hikariConfig.setMaximumPoolSize(1);
-        return new HikariDataSource(hikariConfig);
-    }
+    private static PostgreSQLContainer<?> singletonPostgreSQLContainer;
+    private static DataSource singletonDataSource;
 
     @Bean
     //Alternative to @DynamicPropertySource
     @ServiceConnection
-    //Keep the same bean after restarts
-    @RestartScope
     PostgreSQLContainer<?> postgreSQLContainer() {
-        return new PostgreSQLContainer<>("postgres:16-alpine");
+        if (singletonPostgreSQLContainer == null) {
+            singletonPostgreSQLContainer = new PostgreSQLContainer<>("postgres:16-alpine");
+        }
+        return singletonPostgreSQLContainer;
+    }
+
+    //Avoids datasource recreation
+    @Bean
+    public DataSource dataSource(PostgreSQLContainer<?> postgreSQLContainer) {
+        if (singletonDataSource == null) {
+            HikariConfig hikariConfig = new HikariConfig();
+            hikariConfig.setDriverClassName("org.postgresql.Driver");
+            hikariConfig.setJdbcUrl(postgreSQLContainer.getJdbcUrl());
+            hikariConfig.setUsername(postgreSQLContainer.getUsername());
+            hikariConfig.setPassword(postgreSQLContainer.getPassword());
+            hikariConfig.setMaximumPoolSize(1);
+            singletonDataSource = new HikariDataSource(hikariConfig);
+        }
+        return singletonDataSource;
     }
 
 }

--- a/src/test/java/com/acme/conferencesystem/ContainerConfig.java
+++ b/src/test/java/com/acme/conferencesystem/ContainerConfig.java
@@ -1,6 +1,5 @@
 package com.acme.conferencesystem;
 
-import org.springframework.boot.devtools.restart.RestartScope;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
@@ -11,10 +10,8 @@ public class ContainerConfig {
 
     @Bean
     @ServiceConnection
-    @RestartScope
     public PostgreSQLContainer<?> postgreSQLContainer() {
-        return new PostgreSQLContainer<>("postgres:16-alpine")
-                .withCommand("postgres", "-c", "max_connections=200");
+        return new PostgreSQLContainer<>("postgres:16-alpine");
     }
 
 }

--- a/src/test/java/com/acme/conferencesystem/ContainerConfig.java
+++ b/src/test/java/com/acme/conferencesystem/ContainerConfig.java
@@ -1,5 +1,9 @@
 package com.acme.conferencesystem;
 
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import javax.sql.DataSource;
+import org.springframework.boot.devtools.restart.RestartScope;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
@@ -8,9 +12,25 @@ import org.testcontainers.containers.PostgreSQLContainer;
 @TestConfiguration(proxyBeanMethods = false)
 public class ContainerConfig {
 
+    //Avoids datasource recreation
     @Bean
+    @RestartScope
+    public DataSource dataSource(PostgreSQLContainer<?> postgreSQLContainer) {
+        HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setDriverClassName("org.postgresql.Driver");
+        hikariConfig.setJdbcUrl(postgreSQLContainer.getJdbcUrl());
+        hikariConfig.setUsername(postgreSQLContainer.getUsername());
+        hikariConfig.setPassword(postgreSQLContainer.getPassword());
+        hikariConfig.setMaximumPoolSize(1);
+        return new HikariDataSource(hikariConfig);
+    }
+
+    @Bean
+    //Alternative to @DynamicPropertySource
     @ServiceConnection
-    public PostgreSQLContainer<?> postgreSQLContainer() {
+    //Keep the same bean after restarts
+    @RestartScope
+    PostgreSQLContainer<?> postgreSQLContainer() {
         return new PostgreSQLContainer<>("postgres:16-alpine");
     }
 

--- a/src/test/java/com/acme/conferencesystem/TestApplication.java
+++ b/src/test/java/com/acme/conferencesystem/TestApplication.java
@@ -1,13 +1,30 @@
 package com.acme.conferencesystem;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.devtools.restart.RestartScope;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.PostgreSQLContainer;
 
 class TestApplication {
 
     public static void main(String[] args) {
         SpringApplication.
                 from(Application::main)
-                .with(ContainerConfig.class)
+                .with(LocalContainerConfig.class)
                 .run(args);
     }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    public class LocalContainerConfig {
+
+        @Bean
+        @ServiceConnection
+        @RestartScope
+        PostgreSQLContainer<?> postgreSQLContainer() {
+            return new PostgreSQLContainer<>("postgres:16-alpine");
+        }
+    }
+
 }


### PR DESCRIPTION
When using the annotation @RestartScope that keeps the bean after Devtools restarts or tests restart and to avoid recreation of the Datasources. Using it to avoid PostgreSQL container recreation, I've also defined a Datasource bean with @RestartScope annotation to avoid datasource creation for each context starting after @SpringBootTest.

```log
Caused by: org.postgresql.util.PSQLException: FATAL: sorry, too many clients already
	at org.postgresql.core.v3.ConnectionFactoryImpl.doAuthentication(ConnectionFactoryImpl.java:693)
	at org.postgresql.core.v3.ConnectionFactoryImpl.tryConnect(ConnectionFactoryImpl.java:203)
	at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:258)
	at org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:54)
	at org.postgresql.jdbc.PgConnection.<init>(PgConnection.java:263)
	at org.postgresql.Driver.makeConnection(Driver.java:443)
	at org.postgresql.Driver.connect(Driver.java:297)
	at com.zaxxer.hikari.util.DriverDataSource.getConnection(DriverDataSource.java:138)
	at com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:359)
	at com.zaxxer.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:201)
	at com.zaxxer.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:470)
	at com.zaxxer.hikari.pool.HikariPool.checkFailFast(HikariPool.java:561)
	... 138 more
```

```java
    @Bean
    @RestartScope
    public DataSource dataSource(PostgreSQLContainer<?> postgreSQLContainer) {
        HikariConfig hikariConfig = new HikariConfig();
        hikariConfig.setDriverClassName("org.postgresql.Driver");
        hikariConfig.setJdbcUrl(postgreSQLContainer.getJdbcUrl());
        hikariConfig.setUsername(postgreSQLContainer.getUsername());
        hikariConfig.setPassword(postgreSQLContainer.getPassword());
        hikariConfig.setMaximumPoolSize(10);
        return new HikariDataSource(hikariConfig);
    }
```

or without hikari

```java
    @Bean
    @RestartScope
    DataSource dataSource(PostgreSQLContainer<?> postgreSQLContainer) {
        DriverManagerDataSource dataSource = new DriverManagerDataSource();
        dataSource.setDriverClassName("org.postgresql.Driver");
        dataSource.setUrl(postgreSQLContainer.getJdbcUrl());
        dataSource.setUsername(postgreSQLContainer.getUsername());
        dataSource.setPassword(postgreSQLContainer.getPassword());
        return dataSource;
    }
```

Update:

I've removed the RestartScope from the integration tests because I don't want to use devtools for testing. I've use singleton pattern instead.    

Also reuse is not an option as it's marked as unestable api in test containers.